### PR TITLE
Add Slack newsletter webhook relay workflow

### DIFF
--- a/.github/workflows/slack-newsletter-relay.yml
+++ b/.github/workflows/slack-newsletter-relay.yml
@@ -1,0 +1,30 @@
+name: Slack Newsletter Relay
+
+on:
+  workflow_dispatch:
+    inputs:
+      message:
+        description: Message body to POST to the Slack webhook
+        required: true
+        type: string
+
+jobs:
+  relay:
+    runs-on: ubuntu-latest
+    steps:
+      - name: POST to Slack webhook
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NEWSLETTER_WEBHOOK }}
+          MESSAGE: ${{ inputs.message }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_NEWSLETTER_WEBHOOK secret is not set" >&2
+            exit 1
+          fi
+          payload=$(jq -cn --arg text "$MESSAGE" '{text: $text}')
+          http_code=$(curl -sS -o /tmp/resp -w '%{http_code}' \
+            -X POST -H 'Content-Type: application/json' \
+            --data "$payload" "$SLACK_WEBHOOK_URL")
+          echo "HTTP $http_code"
+          cat /tmp/resp
+          [ "$http_code" = "200" ]


### PR DESCRIPTION
Enables posting to the Newsletter Link Bot Slack webhook from environments where hooks.slack.com is not directly reachable, by relaying through GitHub Actions. The webhook URL is read from the SLACK_NEWSLETTER_WEBHOOK repository secret.

https://claude.ai/code/session_01QEdu3ErypgGEWYBA3vTa9u