### PR TITLE
Fix duplicate Slack relay runs

### DIFF
--- a/.github/workflows/slack-newsletter-relay.yml
+++ b/.github/workflows/slack-newsletter-relay.yml
@@ -2,14 +2,14 @@ name: Slack Newsletter Relay
 
 on:
   issues:
-    types: [opened, labeled]
+    types: [labeled]
 
 permissions:
   issues: write
 
 jobs:
   relay:
-    if: contains(github.event.issue.labels.*.name, 'slack-relay')
+    if: github.event.label.name == 'slack-relay'
     runs-on: ubuntu-latest
     steps:
       - name: POST to Slack webhook


### PR DESCRIPTION
Follow-up to #2. The prior workflow listened for both `opened` and `labeled` issue events and used a repository-level label check, so an issue created with the label applied fired both events and posted the Slack message twice. This change listens only for `labeled` and gates on the specific label in the event payload, so each labeled issue posts exactly once.

https://claude.ai/code/session_01QEdu3ErypgGEWYBA3vTa9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEdu3ErypgGEWYBA3vTa9u)_